### PR TITLE
Add sticky headers for weekends

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <div class="section active">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center">Weekend 1</h1>
+            <h1 class="number-center mb-4 text-center weekend-header">Weekend 1</h1>
             <div class="asset d-flex align-items-center mb-3 gap-2">
               <label class="mb-0" style="width: 100px;">Your asset</label>
               <input name="asset1" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
@@ -106,7 +106,7 @@
       <div class="section">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center">Weekend 2</h1>
+            <h1 class="number-center mb-4 text-center weekend-header">Weekend 2</h1>
             <div class="asset d-flex align-items-center mb-3 gap-2">
               <label class="mb-0" style="width: 100px;">Your asset</label>
               <input name="asset2" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
@@ -202,7 +202,7 @@
       <div class="section">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center">Weekend 3</h1>
+            <h1 class="number-center mb-4 text-center weekend-header">Weekend 3</h1>
             <div class="asset d-flex align-items-center mb-3 gap-2">
               <label class="mb-0" style="width: 100px;">Your asset</label>
               <input name="asset3" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
@@ -303,7 +303,7 @@
       <div class="section">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center">Weekend 4</h1>
+            <h1 class="number-center mb-4 text-center weekend-header">Weekend 4</h1>
             <div class="asset d-flex align-items-center mb-3 gap-2">
               <label class="mb-0" style="width: 100px;">Your asset</label>
               <input name="asset4" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>

--- a/styles.css
+++ b/styles.css
@@ -49,3 +49,11 @@ border-radius: 3px 0 0 3px;
     font-size: 16px;
   }
 }
+
+/* Keep the weekend headers visible while scrolling */
+.weekend-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: #fff;
+}


### PR DESCRIPTION
## Summary
- make each weekend's heading sticky so it stays visible on scroll
- update styles for `weekend-header`

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_685cefa77320832693e1c838391383cf