### PR TITLE
Refactor sticky headers for weekends

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
           <div class="card shadow p-4">
             
             <!-- Sticky Weekend Header -->
-            <div class="weekend-header-sticky bg-white border-bottom mb-3" style="position: sticky; top: 0; z-index: 10;">
+            <div class="weekend-header-sticky bg-white border-bottom mb-3">
               <h1 class="number-center mb-3 text-center">Weekend 1</h1>
               <div class="asset d-flex align-items-center gap-2 mb-3">
                 <label class="mb-0" style="width: 100px;">Your asset</label>
@@ -114,11 +114,13 @@
       <div class="section">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center weekend-header">Weekend 2</h1>
-            <div class="asset d-flex align-items-center mb-3 gap-2">
-              <label class="mb-0" style="width: 100px;">Your asset</label>
-              <input name="asset2" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
-              <button type="button" id="Btn_Manage2" class="btn btn-primary">Click</button>
+            <div class="weekend-header-sticky bg-white border-bottom mb-3">
+              <h1 class="number-center mb-4 text-center">Weekend 2</h1>
+              <div class="asset d-flex align-items-center mb-3 gap-2">
+                <label class="mb-0" style="width: 100px;">Your asset</label>
+                <input name="asset2" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
+                <button type="button" id="Btn_Manage2" class="btn btn-primary">Click</button>
+              </div>
             </div>
             <p class="number-center">Please fill in this form to manage your asset.</p>
             <hr>
@@ -210,11 +212,13 @@
       <div class="section">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center weekend-header">Weekend 3</h1>
-            <div class="asset d-flex align-items-center mb-3 gap-2">
-              <label class="mb-0" style="width: 100px;">Your asset</label>
-              <input name="asset3" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
-              <button type="button" id="Btn_Manage3" class="btn btn-primary">Click</button>
+            <div class="weekend-header-sticky bg-white border-bottom mb-3">
+              <h1 class="number-center mb-4 text-center">Weekend 3</h1>
+              <div class="asset d-flex align-items-center mb-3 gap-2">
+                <label class="mb-0" style="width: 100px;">Your asset</label>
+                <input name="asset3" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
+                <button type="button" id="Btn_Manage3" class="btn btn-primary">Click</button>
+              </div>
             </div>
             <p class="number-center">Please fill in this form to manage your asset.</p>
             <hr>
@@ -311,11 +315,13 @@
       <div class="section">
         <form>
           <div class="card shadow p-4">
-            <h1 class="number-center mb-4 text-center weekend-header">Weekend 4</h1>
-            <div class="asset d-flex align-items-center mb-3 gap-2">
-              <label class="mb-0" style="width: 100px;">Your asset</label>
-              <input name="asset4" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
-              <button type="button" id="Btn_Manage4" class="btn btn-primary">Click</button>
+            <div class="weekend-header-sticky bg-white border-bottom mb-3">
+              <h1 class="number-center mb-4 text-center">Weekend 4</h1>
+              <div class="asset d-flex align-items-center mb-3 gap-2">
+                <label class="mb-0" style="width: 100px;">Your asset</label>
+                <input name="asset4" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
+                <button type="button" id="Btn_Manage4" class="btn btn-primary">Click</button>
+              </div>
             </div>
             <p class="number-center">Please fill in this form to manage your asset.</p>
 

--- a/styles.css
+++ b/styles.css
@@ -57,3 +57,10 @@ border-radius: 3px 0 0 3px;
   z-index: 100;
   background-color: #fff;
 }
+
+/* Reusable sticky container for weekend headers */
+.weekend-header-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
- add `.weekend-header-sticky` CSS class for sticky positioning
- remove inline styles and apply the new class across all weekend sections
- wrap weekend headers and asset fields in `.weekend-header-sticky` container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cf41e6884832697f713a4d18d940d