### PR TITLE
Display current date and time for Monday transactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,42 +66,16 @@
                       <!-- Money Add Column -->
                       <div class="col-md-6">
                         <h6>Money Add</h6>
-                        <div id="mondayAddInputs">
-                          <div class="mb-2 border rounded p-2">
-                            <!-- Date & Time on top -->
-                            <div class="d-flex mb-2 gap-2">
-                              <input type="date" class="form-control" name="Monday_Add_date_0" />
-                              <input type="time" class="form-control" name="Monday_Add_time_0" />
-                            </div>
-                            <!-- Detail + Amount -->
-                            <div class="input-group">
-                              <input type="text" class="form-control" name="Monday_Add_detail_0" placeholder="Detail (e.g. Salary, Bonus)" />
-                              <input type="number" class="form-control" name="Monday_Add_amount_0" placeholder="Amount" />
-                              <button type="button" class="btn btn-success btn-add">+</button>
-                              <button type="button" class="btn btn-danger btn-remove">−</button>
-                            </div>
-                          </div>
+                        <div id="mondayAddInputs" class="transaction-container">
+                          <!-- Rows are generated dynamically via JavaScript -->
                         </div>
                       </div>
 
                       <!-- Money Paid Column -->
                       <div class="col-md-6">
                         <h6>Money Paid</h6>
-                        <div id="mondayPaidInputs">
-                          <div class="mb-2 border rounded p-2">
-                            <!-- Date & Time on top -->
-                            <div class="d-flex mb-2 gap-2">
-                              <input type="date" class="form-control" name="Monday_Paid_date_0" />
-                              <input type="time" class="form-control" name="Monday_Paid_time_0" />
-                            </div>
-                            <!-- Detail + Amount -->
-                            <div class="input-group">
-                              <input type="text" class="form-control" name="Monday_Paid_detail_0" placeholder="Detail (e.g. Rent, Food)" />
-                              <input type="number" class="form-control" name="Monday_Paid_amount_0" placeholder="Amount" />
-                              <button type="button" class="btn btn-success btn-add">+</button>
-                              <button type="button" class="btn btn-danger btn-remove">−</button>
-                            </div>
-                          </div>
+                        <div id="mondayPaidInputs" class="transaction-container">
+                          <!-- Rows are generated dynamically via JavaScript -->
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- replace the Monday modal date/time fields with dynamic containers to display timestamps above each entry instead of manual inputs
- rebuild the Monday Add/Paid persistence logic to generate rows with formatted current date/time labels and store data safely in localStorage

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceb65da1048326a0afe93adc14c35d