### PR TITLE
Add reusable daily transaction modal for Weekend 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,10 @@
             <hr />
 
             <!-- Monday -->
-            <!-- Monday -->
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Monday</b></label>
-                <button type="button" id="showMondaySection" class="btn btn-outline-primary btn-sm">ຄິດໄລ່ເງີນ</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Monday">ຄິດໄລ່ເງີນ</button>
               </div>
 
               <div class="row align-items-center mt-2">
@@ -50,52 +49,18 @@
               </div>
             </div>
 
-            <!-- Modal for Monday -->
-            <div class="modal fade" id="mondayModal" tabindex="-1" aria-labelledby="mondayModalLabel" aria-hidden="true">
-              <div class="modal-dialog modal-dialog-centered modal-lg">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <h5 class="modal-title" id="mondayModalLabel">Monday Details</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                  </div>
-
-                  <div class="modal-body">
-                    <p class="mb-3">Manage your Monday transactions:</p>
-
-                    <div class="row">
-                      <!-- Money Add Column -->
-                      <div class="col-md-6">
-                        <h6>Money Add</h6>
-                        <div id="mondayAddInputs" class="transaction-container">
-                          <!-- Rows are generated dynamically via JavaScript -->
-                        </div>
-                      </div>
-
-                      <!-- Money Paid Column -->
-                      <div class="col-md-6">
-                        <h6>Money Paid</h6>
-                        <div id="mondayPaidInputs" class="transaction-container">
-                          <!-- Rows are generated dynamically via JavaScript -->
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-
             <!-- Tuesday -->
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Tuesday</b></label>
-                <button type="button" class="btn btn-outline-primary btn-sm">+</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Tuesday">ຄິດໄລ່ເງີນ</button>
               </div>
               <div class="row align-items-center mt-2">
                 <div class="col-12 mb-2">
                   <input name="Weekend_1_Tuesday" type="text" class="form-control number-input bg-light border-primary" placeholder="amount" required />
+                </div>
+                <div class="col-12 mb-2">
+                  <p id="Tuesday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
                 </div>
               </div>
             </div>
@@ -104,11 +69,14 @@
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Wednesday</b></label>
-                <button type="button" class="btn btn-outline-primary btn-sm">+</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Wednesday">ຄິດໄລ່ເງີນ</button>
               </div>
               <div class="row align-items-center mt-2">
                 <div class="col-12 mb-2">
                   <input name="Weekend_1_Wednesday" type="text" class="form-control number-input bg-light border-primary" placeholder="amount" required />
+                </div>
+                <div class="col-12 mb-2">
+                  <p id="Wednesday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
                 </div>
               </div>
             </div>
@@ -117,11 +85,14 @@
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Thursday</b></label>
-                <button type="button" class="btn btn-outline-primary btn-sm">+</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Thursday">ຄິດໄລ່ເງີນ</button>
               </div>
               <div class="row align-items-center mt-2">
                 <div class="col-12 mb-2">
                   <input name="Weekend_1_Thursday" type="text" class="form-control number-input bg-light border-primary" placeholder="amount" required />
+                </div>
+                <div class="col-12 mb-2">
+                  <p id="Thursday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
                 </div>
               </div>
             </div>
@@ -130,11 +101,14 @@
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Friday</b></label>
-                <button type="button" class="btn btn-outline-primary btn-sm">+</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Friday">ຄິດໄລ່ເງີນ</button>
               </div>
               <div class="row align-items-center mt-2">
                 <div class="col-12 mb-2">
                   <input name="Weekend_1_Friday" type="text" class="form-control number-input" placeholder="amount" required />
+                </div>
+                <div class="col-12 mb-2">
+                  <p id="Friday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
                 </div>
               </div>
             </div>
@@ -143,11 +117,14 @@
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Saturday</b></label>
-                <button type="button" class="btn btn-outline-primary btn-sm">+</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Saturday">ຄິດໄລ່ເງີນ</button>
               </div>
               <div class="row align-items-center mt-2">
                 <div class="col-12 mb-2">
                   <input name="Weekend_1_Saturday" type="text" class="form-control number-input" placeholder="amount" required />
+                </div>
+                <div class="col-12 mb-2">
+                  <p id="Saturday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
                 </div>
               </div>
             </div>
@@ -156,11 +133,14 @@
             <div class="mb-3">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0"><b>Sunday</b></label>
-                <button type="button" class="btn btn-outline-primary btn-sm">+</button>
+                <button type="button" class="btn btn-outline-primary btn-sm day-modal-trigger" data-day="Sunday">ຄິດໄລ່ເງີນ</button>
               </div>
               <div class="row align-items-center mt-2">
                 <div class="col-12 mb-2">
                   <input name="Weekend_1_Sunday" type="text" class="form-control number-input" placeholder="amount" required />
+                </div>
+                <div class="col-12 mb-2">
+                  <p id="Sunday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
                 </div>
               </div>
             </div>
@@ -169,6 +149,43 @@
 
           </div>
         </form>
+      </div>
+
+      <!-- Day modal reused for all days in Weekend 1 -->
+      <div class="modal fade" id="dayModal" tabindex="-1" aria-labelledby="dayModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="dayModalLabel">Day Details</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+
+            <div class="modal-body">
+              <p class="mb-3" id="dayModalDescription">Manage your transactions:</p>
+
+              <div class="row">
+                <!-- Money Add Column -->
+                <div class="col-md-6">
+                  <h6>Money Add</h6>
+                  <div id="dayAddInputs" class="transaction-container">
+                    <!-- Rows are generated dynamically via JavaScript -->
+                  </div>
+                </div>
+
+                <!-- Money Paid Column -->
+                <div class="col-md-6">
+                  <h6>Money Paid</h6>
+                  <div id="dayPaidInputs" class="transaction-container">
+                    <!-- Rows are generated dynamically via JavaScript -->
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
       </div>
 
 


### PR DESCRIPTION
## Summary
- add reusable modal for managing each day in Weekend 1
- update the Weekend 1 layout with triggers and remaining balance displays for every day
- generalize the JavaScript logic to persist daily add/paid entries and update totals automatically

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceb9d778888326b0fa296056a0ea31