### PR TITLE
Display final Weekend 1 remaining near asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                 <input name="asset1" type="text" class="form-control number-input flex-grow-1" placeholder="amount" required>
                 <button type="button" id="Btn_Manage1" class="btn btn-primary">Click</button>
               </div>
+              <p id="Weekend1_Final_Remaining" class="fw-bold text-success mb-0">Remaining: 0</p>
             </div>
 
             <p class="number-center">Please fill in this form to manage your asset.</p>

--- a/myscripts.js
+++ b/myscripts.js
@@ -109,6 +109,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     });
   });
+
+  const storedFinal = localStorage.getItem("Weekend1_Final_Remaining");
+  if (storedFinal !== null) {
+    updateWeekend1FinalRemainingDisplay(storedFinal, false);
+  }
 });
 
 // Save input values to localStorage
@@ -126,6 +131,26 @@ document.querySelectorAll("input.number-input").forEach((input) => {
     localStorage.setItem(name, input.value);
   });
 });
+
+function updateWeekend1FinalRemainingDisplay(value, persist = true) {
+  const displayEl = document.getElementById("Weekend1_Final_Remaining");
+  if (!displayEl) {
+    return;
+  }
+
+  const numericValue =
+    typeof value === "number" && Number.isFinite(value)
+      ? value
+      : parseNumeric(String(value ?? ""));
+
+  const normalized = Number.isFinite(numericValue) ? numericValue : 0;
+
+  displayEl.textContent = `Remaining: ${normalized.toLocaleString()}`;
+
+  if (persist) {
+    localStorage.setItem("Weekend1_Final_Remaining", normalized.toString());
+  }
+}
 
 function updateWeekend1DayTotals(day, startingBalance = null) {
   const paidData = loadStoredArray(getWeekend1StorageKey(day, "Paid"));
@@ -178,6 +203,8 @@ function calculateWeekend1() {
     const nextBalance = updateWeekend1DayTotals(day, runningBalance);
     runningBalance = Number.isFinite(nextBalance) ? nextBalance : 0;
   });
+
+  updateWeekend1FinalRemainingDisplay(runningBalance);
 }
 
 document


### PR DESCRIPTION
## Summary
- display the overall Weekend 1 remaining balance beneath the asset input
- persist and restore the final Weekend 1 remaining value using localStorage when recalculating

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cec28ae3608326b72a3e35a4719653