### PR TITLE
Add weekly analysis modal and button

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,13 +81,22 @@
               <span class="dot-label">Weekend 4</span>
             </button>
           </div>
-          <button
-            type="button"
-            id="resetPlannerButton"
-            class="btn btn-outline-danger reset-planner-btn"
-          >
-            Reset planner
-          </button>
+          <div class="planner-action-buttons d-flex flex-column flex-sm-row gap-2">
+            <button
+              type="button"
+              id="resetPlannerButton"
+              class="btn btn-outline-danger reset-planner-btn"
+            >
+              Reset planner
+            </button>
+            <button
+              type="button"
+              id="analysisButton"
+              class="btn btn-outline-primary analysis-btn"
+            >
+              Analysis
+            </button>
+          </div>
         </div>
 
         <div
@@ -372,6 +381,28 @@
                     </div>
                   </div>
                 </div>
+                <div class="modal-footer border-0 pt-0">
+                  <button type="button" class="btn btn-light" data-bs-dismiss="modal">Close</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal fade" id="analysisModal" tabindex="-1" aria-labelledby="analysisModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered modal-lg">
+              <div class="modal-content analysis-modal">
+                <div class="modal-header border-0">
+                  <div>
+                    <p class="modal-eyebrow text-uppercase text-muted mb-1">Weekly insights</p>
+                    <h5 class="modal-title" id="analysisModalLabel">Planner Analysis</h5>
+                  </div>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body pt-0">
+                  <div id="analysisContent" class="analysis-content"></div>
+                </div>
+
                 <div class="modal-footer border-0 pt-0">
                   <button type="button" class="btn btn-light" data-bs-dismiss="modal">Close</button>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,21 @@ body.app-body {
   align-self: flex-start;
 }
 
+.planner-action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.analysis-btn {
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  white-space: nowrap;
+  align-self: flex-start;
+}
+
 .reset-feedback {
   box-shadow: 0 12px 24px rgba(59, 91, 219, 0.15);
   border-radius: 999px;
@@ -383,6 +398,132 @@ body.app-body {
 .current-datetime {
   font-size: 0.75rem;
   letter-spacing: 0.08em;
+}
+
+.analysis-modal {
+  border-radius: 24px;
+  border: none;
+  box-shadow: var(--shadow-soft);
+}
+
+.analysis-modal .modal-body {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.analysis-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.analysis-weekend-card {
+  background: var(--surface);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.14);
+}
+
+.analysis-weekend-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.analysis-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.1rem;
+  margin-top: 1.25rem;
+}
+
+.analysis-metric-label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.analysis-metric-value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.analysis-highlight {
+  margin-top: 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--primary-strong);
+}
+
+.analysis-overview-highlight {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.analysis-day-table {
+  margin-top: 1.25rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.analysis-day-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  font-size: 0.9rem;
+}
+
+.analysis-day-row:last-child {
+  border-bottom: none;
+}
+
+.analysis-day-name {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.analysis-day-added {
+  color: var(--success);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.analysis-day-spent {
+  color: #d6336c;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.analysis-net-positive {
+  color: var(--success);
+}
+
+.analysis-net-negative {
+  color: #d6336c;
+}
+
+.analysis-weekend-badge {
+  background: rgba(59, 91, 219, 0.08);
+  color: var(--primary-strong);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
 }
 
 @media (max-width: 991.98px) {


### PR DESCRIPTION
## Summary
- add an Analysis action next to Reset Planner to surface insights on demand
- compute aggregate and per-weekend spending metrics and render them inside a reusable analysis modal
- style the new analysis controls and modal layout for consistency with the existing UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfd89fda2483269477cc7ddab3a526