### PR TITLE
Add support for locking a preferred weekend

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,47 +39,60 @@
             Weekend 1 of 4
           </div>
 
-          <div class="progress-dots" role="tablist" aria-label="Select weekend">
-            <button
-              type="button"
-              class="progress-dot active"
-              data-index="0"
-              aria-label="Show Weekend 1"
-              aria-pressed="true"
-            >
-              <span class="dot"></span>
-              <span class="dot-label">Weekend 1</span>
-            </button>
-            <button
-              type="button"
-              class="progress-dot"
-              data-index="1"
-              aria-label="Show Weekend 2"
-              aria-pressed="false"
-            >
-              <span class="dot"></span>
-              <span class="dot-label">Weekend 2</span>
-            </button>
-            <button
-              type="button"
-              class="progress-dot"
-              data-index="2"
-              aria-label="Show Weekend 3"
-              aria-pressed="false"
-            >
-              <span class="dot"></span>
-              <span class="dot-label">Weekend 3</span>
-            </button>
-            <button
-              type="button"
-              class="progress-dot"
-              data-index="3"
-              aria-label="Show Weekend 4"
-              aria-pressed="false"
-            >
-              <span class="dot"></span>
-              <span class="dot-label">Weekend 4</span>
-            </button>
+          <div class="weekend-progress-group d-flex flex-column align-items-center gap-2">
+            <div class="progress-dots" role="tablist" aria-label="Select weekend">
+              <button
+                type="button"
+                class="progress-dot active"
+                data-index="0"
+                aria-label="Show Weekend 1"
+                aria-pressed="true"
+              >
+                <span class="dot"></span>
+                <span class="dot-label">Weekend 1</span>
+              </button>
+              <button
+                type="button"
+                class="progress-dot"
+                data-index="1"
+                aria-label="Show Weekend 2"
+                aria-pressed="false"
+              >
+                <span class="dot"></span>
+                <span class="dot-label">Weekend 2</span>
+              </button>
+              <button
+                type="button"
+                class="progress-dot"
+                data-index="2"
+                aria-label="Show Weekend 3"
+                aria-pressed="false"
+              >
+                <span class="dot"></span>
+                <span class="dot-label">Weekend 3</span>
+              </button>
+              <button
+                type="button"
+                class="progress-dot"
+                data-index="3"
+                aria-label="Show Weekend 4"
+                aria-pressed="false"
+              >
+                <span class="dot"></span>
+                <span class="dot-label">Weekend 4</span>
+              </button>
+            </div>
+            <div class="weekend-lock-control d-flex flex-column flex-sm-row align-items-center justify-content-center gap-2">
+              <button
+                type="button"
+                id="lockWeekendButton"
+                class="btn btn-outline-secondary lock-weekend-btn"
+                aria-pressed="false"
+              >
+                Lock Weekend 1
+              </button>
+              <span id="lockStatus" class="lock-status text-muted small">No weekend locked.</span>
+            </div>
           </div>
           <div class="planner-action-buttons d-flex flex-column flex-sm-row gap-2">
             <button

--- a/styles.css
+++ b/styles.css
@@ -67,10 +67,41 @@ body.app-body {
   margin-bottom: 1.5rem;
 }
 
+.weekend-progress-group {
+  width: 100%;
+}
+
 .weekend-counter {
   letter-spacing: 0.2em;
   font-size: 0.75rem;
   color: var(--text-muted);
+}
+
+.weekend-lock-control {
+  text-align: center;
+}
+
+.lock-weekend-btn {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.4rem 1.2rem;
+  transition: color var(--transition), border-color var(--transition),
+    background var(--transition);
+}
+
+.lock-weekend-btn.is-locked {
+  background: rgba(26, 161, 121, 0.1);
+  border-color: rgba(26, 161, 121, 0.6);
+  color: var(--success);
+}
+
+.lock-status {
+  min-height: 1.25rem;
+}
+
+.lock-status.active {
+  color: var(--success) !important;
+  font-weight: 600;
 }
 
 .reset-planner-btn {
@@ -162,6 +193,15 @@ body.app-body {
   border-color: rgba(59, 91, 219, 0.6);
   transform: translateY(-2px);
   box-shadow: 0 16px 32px rgba(59, 91, 219, 0.25);
+}
+
+.progress-dot.locked {
+  border-color: rgba(26, 161, 121, 0.6);
+  color: var(--success);
+}
+
+.progress-dot.locked .dot {
+  background: var(--success);
 }
 
 .progress-dot.active .dot,


### PR DESCRIPTION
## Summary
- introduce a lock weekend control that lets users choose which weekend should load by default
- persist the preferred weekend in localStorage and highlight the locked dot in the navigation
- update reset logic and styling to reflect the new locking experience

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff22f95f083268b51b8caa8262f0d