### PR TITLE
Revamp Money Care planner UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,16 +17,114 @@
   />
 </head>
 <body class="app-body">
-  <div class="app-shell">
-    <header class="page-hero text-center">
-      <span class="badge hero-badge text-uppercase">Money Care</span>
-      <h1 class="hero-title display-5 fw-bold">Money Care Planner</h1>
-      <p class="hero-lead lead text-muted mb-0">
-        Set your weekend budgets, log your cash flow, and watch the balance update in real time.
-      </p>
-    </header>
+    <div class="app-shell">
+      <header class="page-hero text-center">
+        <span class="badge hero-badge text-uppercase">Money Care</span>
+        <h1 class="hero-title display-5 fw-bold">Money Care Planner</h1>
+        <p class="hero-lead lead text-muted mb-0">
+          Set your weekend budgets, log your cash flow, and watch the balance update in real time.
+        </p>
+        <div
+          class="hero-actions d-flex flex-column flex-sm-row align-items-center justify-content-center gap-3 mt-4"
+        >
+          <a class="btn hero-cta" href="#weekend-sections">Start planning</a>
+          <div class="hero-note text-muted">
+            <span class="hero-note-icon" aria-hidden="true">✓</span>
+            No sign-in required &mdash; your data stays on this device.
+          </div>
+        </div>
+      </header>
 
-    <main class="container mt-4">
+      <section class="planner-overview container" aria-label="Planner highlights">
+        <div class="row g-4">
+          <div class="col-md-4">
+            <article class="overview-card h-100">
+              <span class="overview-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img">
+                  <path
+                    d="M4 16l5-5 4 4 7-7"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M16 6h4v4"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+              <h3 class="overview-title">Plan with clarity</h3>
+              <p class="overview-copy">
+                Set weekend goals and keep your running balance visible at the top of every schedule.
+              </p>
+            </article>
+          </div>
+          <div class="col-md-4">
+            <article class="overview-card h-100">
+              <span class="overview-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img">
+                  <rect
+                    x="3"
+                    y="5"
+                    width="18"
+                    height="16"
+                    rx="2"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M8 3v4M16 3v4M3 11h18"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+              <h3 class="overview-title">Daily check-ins</h3>
+              <p class="overview-copy">
+                Break down income and spending for every day of the week to spot patterns instantly.
+              </p>
+            </article>
+          </div>
+          <div class="col-md-4">
+            <article class="overview-card h-100">
+              <span class="overview-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img">
+                  <path
+                    d="M4 14l4-4 3 3 5-5 4 4"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M4 18h16"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+              <h3 class="overview-title">Instant insights</h3>
+              <p class="overview-copy">
+                Use the analysis modal to compare weekends, track savings, and celebrate progress.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <main class="container mt-5 mt-md-4">
       <div class="slideshow-wrapper">
         <div
           class="weekend-navigation d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3"
@@ -136,7 +234,7 @@
                 <div class="weekend-header-sticky bg-white rounded-4 shadow-sm p-3 p-md-4 mb-4">
                   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2">
                     <h1 class="number-center mb-0 text-center text-md-start">Weekend 1</h1>
-                    <p id="Weekend1_Final_Remaining" class="fw-bold text-success mb-0">Remaining: 0</p>
+                    <p id="Weekend1_Final_Remaining" class="balance-chip">Remaining: 0</p>
                   </div>
                   <div class="asset d-flex flex-column flex-md-row align-items-md-center gap-2 mt-3">
                     <label class="mb-0 text-uppercase text-muted asset-label" style="width: auto;">Your asset</label>
@@ -151,13 +249,14 @@
                   </div>
                 </div>
 
-                <p class="number-center text-muted text-center mb-4">
-                  Please fill in this form to manage your asset.
+                <p class="weekend-helper text-center mb-4">
+                  Log your additions and spending below. Tap a day to open detailed transactions.
                 </p>
                 <div class="soft-divider mb-4"></div>
 
-                <!-- Monday -->
-                <div class="mb-4 day-block">
+                <div class="weekend-content">
+                  <!-- Monday -->
+                  <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Monday</b></label>
                     <button
@@ -181,13 +280,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Monday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Monday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Tuesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Tuesday</b></label>
                     <button
@@ -210,13 +309,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Tuesday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Tuesday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Wednesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Wednesday</b></label>
                     <button
@@ -239,13 +338,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Wednesday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Wednesday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Thursday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Thursday</b></label>
                     <button
@@ -268,13 +367,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Thursday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Thursday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Friday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Friday</b></label>
                     <button
@@ -297,13 +396,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Friday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Friday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Saturday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Saturday</b></label>
                     <button
@@ -326,13 +425,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Saturday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Saturday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Sunday -->
-                <div class="mb-3 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Sunday</b></label>
                     <button
@@ -355,9 +454,11 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Sunday_1_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Sunday_1_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
+                </div>
+
                 </div>
 
                 <div class="soft-divider mt-4"></div>
@@ -430,7 +531,7 @@
                 <div class="weekend-header-sticky bg-white rounded-4 shadow-sm p-3 p-md-4 mb-4">
                   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2">
                     <h1 class="number-center mb-0 text-center text-md-start">Weekend 2</h1>
-                    <p id="Weekend2_Final_Remaining" class="fw-bold text-success mb-0">Remaining: 0</p>
+                    <p id="Weekend2_Final_Remaining" class="balance-chip">Remaining: 0</p>
                   </div>
                   <div class="asset d-flex flex-column flex-md-row align-items-md-center gap-2 mt-3">
                     <label class="mb-0 text-uppercase text-muted asset-label" style="width: auto;">Your asset</label>
@@ -445,13 +546,14 @@
                   </div>
                 </div>
 
-                <p class="number-center text-muted text-center mb-4">
-                  Please fill in this form to manage your asset.
+                <p class="weekend-helper text-center mb-4">
+                  Log your additions and spending below. Tap a day to open detailed transactions.
                 </p>
                 <div class="soft-divider mb-4"></div>
 
-                <!-- Monday -->
-                <div class="mb-4 day-block">
+                <div class="weekend-content">
+                  <!-- Monday -->
+                  <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Monday</b></label>
                     <button
@@ -475,13 +577,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Monday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Monday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Tuesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Tuesday</b></label>
                     <button
@@ -504,13 +606,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Tuesday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Tuesday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Wednesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Wednesday</b></label>
                     <button
@@ -533,13 +635,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Wednesday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Wednesday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Thursday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Thursday</b></label>
                     <button
@@ -562,13 +664,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Thursday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Thursday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Friday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Friday</b></label>
                     <button
@@ -591,13 +693,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Friday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Friday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Saturday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Saturday</b></label>
                     <button
@@ -620,13 +722,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Saturday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Saturday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Sunday -->
-                <div class="mb-3 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Sunday</b></label>
                     <button
@@ -649,9 +751,11 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Sunday_2_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Sunday_2_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
+                </div>
+
                 </div>
 
                 <div class="soft-divider mt-4"></div>
@@ -666,7 +770,7 @@
                 <div class="weekend-header-sticky bg-white rounded-4 shadow-sm p-3 p-md-4 mb-4">
                   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2">
                     <h1 class="number-center mb-0 text-center text-md-start">Weekend 3</h1>
-                    <p id="Weekend3_Final_Remaining" class="fw-bold text-success mb-0">Remaining: 0</p>
+                    <p id="Weekend3_Final_Remaining" class="balance-chip">Remaining: 0</p>
                   </div>
                   <div class="asset d-flex flex-column flex-md-row align-items-md-center gap-2 mt-3">
                     <label class="mb-0 text-uppercase text-muted asset-label" style="width: auto;">Your asset</label>
@@ -681,13 +785,14 @@
                   </div>
                 </div>
 
-                <p class="number-center text-muted text-center mb-4">
-                  Please fill in this form to manage your asset.
+                <p class="weekend-helper text-center mb-4">
+                  Log your additions and spending below. Tap a day to open detailed transactions.
                 </p>
                 <div class="soft-divider mb-4"></div>
 
-                <!-- Monday -->
-                <div class="mb-4 day-block">
+                <div class="weekend-content">
+                  <!-- Monday -->
+                  <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Monday</b></label>
                     <button
@@ -711,13 +816,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Monday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Monday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Tuesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Tuesday</b></label>
                     <button
@@ -740,13 +845,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Tuesday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Tuesday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Wednesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Wednesday</b></label>
                     <button
@@ -769,13 +874,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Wednesday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Wednesday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Thursday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Thursday</b></label>
                     <button
@@ -798,13 +903,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Thursday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Thursday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Friday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Friday</b></label>
                     <button
@@ -827,13 +932,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Friday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Friday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Saturday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Saturday</b></label>
                     <button
@@ -856,13 +961,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Saturday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Saturday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Sunday -->
-                <div class="mb-3 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Sunday</b></label>
                     <button
@@ -885,9 +990,11 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Sunday_3_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Sunday_3_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
+                </div>
+
                 </div>
 
                 <div class="soft-divider mt-4"></div>
@@ -902,7 +1009,7 @@
                 <div class="weekend-header-sticky bg-white rounded-4 shadow-sm p-3 p-md-4 mb-4">
                   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2">
                     <h1 class="number-center mb-0 text-center text-md-start">Weekend 4</h1>
-                    <p id="Weekend4_Final_Remaining" class="fw-bold text-success mb-0">Remaining: 0</p>
+                    <p id="Weekend4_Final_Remaining" class="balance-chip">Remaining: 0</p>
                   </div>
                   <div class="asset d-flex flex-column flex-md-row align-items-md-center gap-2 mt-3">
                     <label class="mb-0 text-uppercase text-muted asset-label" style="width: auto;">Your asset</label>
@@ -917,13 +1024,14 @@
                   </div>
                 </div>
 
-                <p class="number-center text-muted text-center mb-4">
-                  Please fill in this form to manage your asset.
+                <p class="weekend-helper text-center mb-4">
+                  Log your additions and spending below. Tap a day to open detailed transactions.
                 </p>
                 <div class="soft-divider mb-4"></div>
 
-                <!-- Monday -->
-                <div class="mb-4 day-block">
+                <div class="weekend-content">
+                  <!-- Monday -->
+                  <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Monday</b></label>
                     <button
@@ -947,13 +1055,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Monday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Monday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Tuesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Tuesday</b></label>
                     <button
@@ -976,13 +1084,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Tuesday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Tuesday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Wednesday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Wednesday</b></label>
                     <button
@@ -1005,13 +1113,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Wednesday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Wednesday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Thursday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Thursday</b></label>
                     <button
@@ -1034,13 +1142,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Thursday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Thursday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Friday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Friday</b></label>
                     <button
@@ -1063,13 +1171,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Friday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Friday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Saturday -->
-                <div class="mb-4 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Saturday</b></label>
                     <button
@@ -1092,13 +1200,13 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Saturday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Saturday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Sunday -->
-                <div class="mb-3 day-block">
+                <div class="day-block">
                   <div class="day-header">
                     <label class="form-label mb-0"><b>Sunday</b></label>
                     <button
@@ -1121,9 +1229,11 @@
                       />
                     </div>
                     <div class="col-12">
-                      <p id="Sunday_4_addTotal" class="fw-bold text-success">Remaining: 0</p>
+                      <p id="Sunday_4_addTotal" class="day-remaining">Remaining: 0</p>
                     </div>
                   </div>
+                </div>
+
                 </div>
 
                 <div class="soft-divider mt-4"></div>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,9 @@
   --primary: #3b5bdb;
   --primary-strong: #2844c0;
   --success: #1aa179;
+  --accent-warm: #f76707;
+  --accent-soft: #fff5f0;
+  --hero-note: rgba(59, 91, 219, 0.12);
   --text-color: #1f2933;
   --text-muted: #6b7a99;
   --chip-bg: rgba(234, 76, 137, 0.12);
@@ -27,6 +30,34 @@ body.app-body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background: var(--app-gradient);
   color: var(--text-color);
+  position: relative;
+  overflow-x: hidden;
+}
+
+body.app-body::before,
+body.app-body::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.4;
+  z-index: -1;
+}
+
+body.app-body::before {
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(59, 91, 219, 0.25), rgba(59, 91, 219, 0));
+  top: -120px;
+  right: -160px;
+}
+
+body.app-body::after {
+  width: 480px;
+  height: 480px;
+  background: radial-gradient(circle at center, rgba(247, 103, 7, 0.18), rgba(247, 103, 7, 0));
+  bottom: -180px;
+  left: -200px;
 }
 
 .app-shell {
@@ -55,6 +86,104 @@ body.app-body {
 .hero-lead {
   max-width: 640px;
   margin: 1rem auto 0;
+}
+
+.hero-actions {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.hero-cta {
+  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
+  border: none;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 20px 40px rgba(59, 91, 219, 0.35);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.hero-cta:hover,
+.hero-cta:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 28px 54px rgba(59, 91, 219, 0.45);
+  color: #fff;
+}
+
+.hero-note {
+  background: var(--hero-note);
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.hero-note-icon {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  color: var(--primary-strong);
+  font-weight: 700;
+  box-shadow: 0 10px 20px rgba(59, 91, 219, 0.25);
+}
+
+.planner-overview {
+  margin-top: 2.5rem;
+}
+
+.overview-card {
+  position: relative;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 22px;
+  padding: 1.8rem 1.5rem;
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.overview-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(59, 91, 219, 0.08), rgba(59, 91, 219, 0));
+  pointer-events: none;
+}
+
+.overview-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+}
+
+.overview-icon {
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: rgba(59, 91, 219, 0.12);
+  color: var(--primary-strong);
+  margin-bottom: 1.25rem;
+}
+
+.overview-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.overview-copy {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
 }
 
 .slideshow-wrapper {
@@ -223,10 +352,24 @@ body.app-body {
 }
 
 .weekend-card {
-  background: var(--surface);
+  position: relative;
+  z-index: 0;
+  background: rgba(255, 255, 255, 0.92);
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.2);
   box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.weekend-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(59, 91, 219, 0.08), rgba(59, 91, 219, 0));
+  opacity: 0.45;
+  z-index: -1;
+  pointer-events: none;
 }
 
 .weekend-card h1 {
@@ -234,11 +377,42 @@ body.app-body {
   font-weight: 700;
 }
 
+.weekend-helper {
+  font-size: 0.95rem;
+  color: var(--text-muted) !important;
+}
+
+.balance-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(26, 161, 121, 0.12);
+  border-radius: 999px;
+  padding: 0.45rem 1.2rem;
+  font-weight: 700;
+  color: var(--success);
+  font-variant-numeric: tabular-nums;
+  box-shadow: 0 12px 24px rgba(26, 161, 121, 0.16);
+}
+
+.day-remaining {
+  margin-bottom: 0;
+  background: rgba(26, 161, 121, 0.08);
+  color: var(--success);
+  font-weight: 600;
+  border-radius: 12px;
+  display: inline-flex;
+  padding: 0.35rem 0.9rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .weekend-header-sticky {
   position: sticky;
   top: -1.5rem;
   z-index: 10;
   border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(18px);
 }
 
 .weekend-header-sticky.is-stuck {
@@ -281,16 +455,29 @@ body.app-body {
   );
 }
 
+.weekend-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .day-block {
-  background: var(--surface-muted);
+  background: rgba(255, 255, 255, 0.8);
   border-radius: 18px;
-  padding: 1.25rem;
+  padding: 1.35rem;
   transition: transform var(--transition), box-shadow var(--transition);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(6px);
 }
 
 .day-block:hover {
   transform: translateY(-3px);
   box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+}
+
+@media (min-width: 992px) {
+  .weekend-content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .day-header {
@@ -319,7 +506,7 @@ body.app-body {
   padding: 0.75rem 1rem;
   border-radius: 14px;
   border: 1px solid rgba(148, 163, 184, 0.4);
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(248, 250, 255, 0.9);
   transition: border-color var(--transition), box-shadow var(--transition),
     background-color var(--transition);
 }
@@ -589,6 +776,18 @@ body.app-body {
     padding: 0 1.25rem 1.5rem;
   }
 
+  .hero-actions {
+    gap: 1rem;
+  }
+
+  .hero-note {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+    padding: 0.75rem 1rem;
+    line-height: 1.5;
+  }
+
   .nav-button {
     top: auto;
     bottom: -2.5rem;
@@ -616,6 +815,10 @@ body.app-body {
 @media (max-width: 575.98px) {
   body {
     font-size: 14px;
+  }
+
+  .overview-card {
+    padding: 1.5rem 1.35rem;
   }
 
   .day-block {


### PR DESCRIPTION
## Summary
- add hero call-to-action banner and highlight cards to welcome users to the planner
- refresh weekend cards with glassmorphism styling, pill balance indicators, and responsive two-column day layout
- improve day totals and inputs with richer feedback styling for clearer daily tracking

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cff5513610832698d5e9581fbd97e8