### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,13 +219,6 @@
           All saved planner data has been cleared.
         </div>
 
-        <button id="prevBtn" class="nav-button" type="button" aria-label="Previous weekend">
-          &#10094;
-        </button>
-        <button id="nextBtn" class="nav-button" type="button" aria-label="Next weekend">
-          &#10095;
-        </button>
-
         <div id="weekend-sections">
           <!-- Weekend 1 -->
           <div class="section active">
@@ -1241,6 +1234,14 @@
             </form>
           </div>
 
+        </div>
+        <div class="nav-button-row" role="group" aria-label="Weekend navigation">
+          <button id="prevBtn" class="nav-button" type="button" aria-label="Previous weekend">
+            &#10094;
+          </button>
+          <button id="nextBtn" class="nav-button" type="button" aria-label="Next weekend">
+            &#10095;
+          </button>
         </div>
       </div>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -768,6 +768,11 @@ body.app-body::after {
 }
 
 @media (max-width: 767.98px) {
+  body.app-body::before,
+  body.app-body::after {
+    display: none;
+  }
+
   .app-shell {
     padding: 2rem 0 4rem;
   }
@@ -788,27 +793,55 @@ body.app-body::after {
     line-height: 1.5;
   }
 
+  .weekend-navigation {
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+
+  .weekend-progress-group {
+    width: 100%;
+  }
+
+  .progress-dots {
+    width: 100%;
+    gap: 0.65rem;
+  }
+
+  .progress-dot {
+    flex: 1 1 calc(50% - 0.65rem);
+    justify-content: center;
+    font-size: 0.8rem;
+  }
+
+  .planner-action-buttons {
+    justify-content: center;
+  }
+
+  .nav-button-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
   .nav-button {
+    position: static;
     top: auto;
-    bottom: -2.5rem;
-    transform: translateY(0);
+    bottom: auto;
+    left: auto;
+    right: auto;
+    transform: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem 1.1rem;
+    font-size: 1rem;
+    box-shadow: 0 14px 28px rgba(59, 91, 219, 0.3);
   }
 
   .nav-button:hover,
   .nav-button:focus {
     transform: translateY(-2px);
-  }
-
-  #prevBtn {
-    left: calc(50% - 3.5rem);
-  }
-
-  #nextBtn {
-    right: calc(50% - 3.5rem);
-  }
-
-  .progress-dot {
-    font-size: 0.8rem;
   }
 }
 
@@ -823,6 +856,14 @@ body.app-body::after {
 
   .day-block {
     padding: 1rem;
+  }
+
+  .planner-action-buttons {
+    gap: 1rem;
+  }
+
+  .planner-action-buttons .btn {
+    width: min(100%, 240px);
   }
 
   .transaction-container {


### PR DESCRIPTION
## Summary
- Move the weekend navigation controls into a dedicated row so the previous/next buttons stay accessible and centered on phones.
- Tweak mobile breakpoints to hide decorative background flares, stretch the progress dots, and center planner actions to eliminate horizontal overflow on small screens.

## Testing
- Manually viewed `index.html` at 320px and 375px widths.

------
https://chatgpt.com/codex/tasks/task_e_68d3ed4eeab483269efff7ef1ca80d43